### PR TITLE
Refactor yaml serialization & deserialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -106,7 +106,7 @@ dependencies = [
  "atty",
  "bitflags",
  "strsim 0.8.0",
- "textwrap",
+ "textwrap 0.11.0",
  "unicode-width",
  "vec_map",
 ]
@@ -349,6 +349,12 @@ name = "doc-comment"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
+
+[[package]]
+name = "dtoa"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56899898ce76aaf4a0f24d914c97ea6ed976d42fec6ad33fcbb0a1103e07b2b0"
 
 [[package]]
 name = "either"
@@ -790,6 +796,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.8.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15654ed4ab61726bf918a39cb8d98a2e2995b002387807fa6ba58fdf7f59bb23"
+dependencies = [
+ "dtoa",
+ "linked-hash-map",
+ "serde",
+ "yaml-rust",
+]
+
+[[package]]
 name = "sha1"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -838,6 +856,12 @@ dependencies = [
  "unicode-width",
  "vte",
 ]
+
+[[package]]
+name = "smawk"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f67ad224767faa3c7d8b6d91985b78e70a1324408abcb1cfcc2be4c06bc06043"
 
 [[package]]
 name = "snafu"
@@ -1008,6 +1032,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "textwrap"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0066c8d12af8b5acd21e00547c3797fde4e8677254a7ee429176ccebbe93dd80"
+dependencies = [
+ "smawk",
+ "unicode-linebreak",
+ "unicode-width",
+]
+
+[[package]]
 name = "thread_local"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1095,6 +1130,15 @@ dependencies = [
  "nix 0.14.1",
  "term",
  "unicode-width",
+]
+
+[[package]]
+name = "unicode-linebreak"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05a31f45d18a3213b918019f78fe6a73a14ab896807f0aaf5622aa0684749455"
+dependencies = [
+ "regex",
 ]
 
 [[package]]
@@ -1286,13 +1330,14 @@ dependencies = [
  "dirs 3.0.2",
  "matter",
  "serde",
+ "serde_yaml",
  "shellexpand",
  "skim",
  "snafu",
  "structopt",
  "tempfile",
+ "textwrap 0.14.2",
  "toml",
  "walkdir",
  "xdg",
- "yaml-rust",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ structopt   = "0.3.0"
 toml        = "0.5.8"
 walkdir     = "2.3.2"
 xdg         = "2.2.0"
-yaml-rust   = "0.4.5"
+serde_yaml  = "0.8.0"
 
 [dependencies.serde]
 version  = "1.0.0"
@@ -35,3 +35,4 @@ features = ["derive"]
 
 [dev-dependencies]
 tempfile = "3.2.0"
+textwrap = "0.14.2"

--- a/justfile
+++ b/justfile
@@ -1,5 +1,4 @@
-default:
-	just --list
+default: fmt ci
 
 ci: build test clippy fmt-check
 

--- a/src/common.rs
+++ b/src/common.rs
@@ -24,14 +24,13 @@ pub use snafu::{ResultExt, Snafu};
 pub use structopt::StructOpt;
 pub use toml;
 pub use walkdir::WalkDir;
-pub use yaml_rust::{Yaml, YamlEmitter, YamlLoader};
 
 // modules
 pub(crate) use crate::error;
 
 // test crates
 #[cfg(test)]
-pub use tempfile::TempDir;
+pub use {tempfile::TempDir, textwrap::dedent};
 
 // structs and enums
 pub use crate::{

--- a/src/directory.rs
+++ b/src/directory.rs
@@ -35,7 +35,7 @@ impl Directory {
             == self.ext
       })
       .for_each(|entry| {
-        notes.push(Note::new(entry));
+        notes.push(Note::new(entry).unwrap());
       });
 
     Ok(notes)
@@ -69,7 +69,14 @@ impl Directory {
     let ret = &self
       .notes()?
       .iter()
-      .filter(|note| note.matter.tags.contains(&tag.to_string()))
+      .filter(|note| {
+        note
+          .matter
+          .tags
+          .clone()
+          .unwrap_or_default()
+          .contains(&tag.to_string())
+      })
       .cloned()
       .collect::<Vec<Note>>();
 
@@ -90,7 +97,14 @@ impl Directory {
     let ret = &self
       .notes()?
       .iter()
-      .filter(|note| note.matter.links.contains(&name.to_string()))
+      .filter(|note| {
+        note
+          .matter
+          .links
+          .clone()
+          .unwrap_or_default()
+          .contains(&name.to_string())
+      })
       .cloned()
       .collect::<Vec<Note>>();
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -32,6 +32,16 @@ pub enum Error {
     var:    String,
   },
 
+  #[snafu(display("Failed to serialize frontmatter."))]
+  MatterSerialize {
+    source: serde_yaml::Error,
+  },
+
+  #[snafu(display("Failed to deserialize frontmatter."))]
+  MatterDeserialize {
+    source: serde_yaml::Error,
+  },
+
   #[snafu(display("Note with name `{}` does not exist.", name))]
   NoteNotFound {
     name: String,

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -266,10 +266,15 @@ impl Handler {
 
     let (tx, rx): (SkimItemSender, SkimItemReceiver) = unbounded();
 
-    note.matter.links.iter().for_each(|link| {
-      tx.send(Arc::new(Note::new(self.directory.path.join(link))))
-        .unwrap();
-    });
+    note
+      .matter
+      .links
+      .unwrap_or_default()
+      .iter()
+      .for_each(|link| {
+        tx.send(Arc::new(Note::new(self.directory.path.join(link)).unwrap()))
+          .unwrap();
+      });
 
     drop(tx);
 

--- a/src/matter.rs
+++ b/src/matter.rs
@@ -49,7 +49,7 @@ mod tests {
         - c
       "#;
 
-    // This is what we want
+    // This is what we want (when deserializing)
     let want = r#"
       ---
       name: 123-a
@@ -71,15 +71,15 @@ mod tests {
 
   #[test]
   fn from() {
-    let (matter, _, want) = setup();
-    let res = Matter::into(matter).unwrap();
-    assert_eq!(res, want);
-  }
-
-  #[test]
-  fn to_string() {
     let (matter, as_str, _) = setup();
     let res: Matter = Matter::from(as_str.as_str()).unwrap();
     assert_eq!(res, matter);
+  }
+
+  #[test]
+  fn into() {
+    let (matter, _, want) = setup();
+    let res = Matter::into(matter).unwrap();
+    assert_eq!(res, want);
   }
 }

--- a/src/note.rs
+++ b/src/note.rs
@@ -23,24 +23,30 @@ impl SkimItem for Note {
 }
 
 impl Note {
-  pub fn new(path: PathBuf) -> Self {
+  pub fn new(path: PathBuf) -> Result<Self, Error> {
     let id = NoteId::parse(path.file_name().unwrap().to_str().unwrap()).unwrap();
 
     let (matter, content) = matter::matter(&fs::read_to_string(&path).unwrap()).unwrap();
 
-    let matter = Matter::from(matter.as_str());
+    let matter = Matter::from(matter.as_str())?;
 
-    Self {
+    Ok(Self {
       id,
       path,
       matter,
       content,
-    }
+    })
   }
 
   /// Checks if a link exists between the current note and `name`.
   pub fn has_link(&self, name: &str) -> bool {
-    if self.matter.links.contains(&name.to_owned()) {
+    if self
+      .matter
+      .links
+      .clone()
+      .unwrap_or_default()
+      .contains(&name.to_owned())
+    {
       return true;
     }
     false
@@ -48,7 +54,13 @@ impl Note {
 
   /// Checks if a tag `name` exists within this notes tags.
   pub fn has_tag(&self, name: &str) -> bool {
-    if self.matter.tags.contains(&name.to_owned()) {
+    if self
+      .matter
+      .tags
+      .clone()
+      .unwrap_or_default()
+      .contains(&name.to_owned())
+    {
       return true;
     }
     false
@@ -71,6 +83,8 @@ impl Note {
     let mut new = self
       .matter
       .links
+      .clone()
+      .unwrap_or_default()
       .iter()
       .map(|link| link.to_owned())
       .collect::<Vec<String>>();
@@ -81,17 +95,17 @@ impl Note {
 
     file
       .write_all(
-        &Matter::into_string(Matter {
-          links: new,
+        &Matter::into(Matter {
+          links: Some(new),
           ..self.matter.clone()
-        })
+        })?
         .as_bytes(),
       )
       .unwrap();
 
     file.write_all(&self.content.as_bytes()).unwrap();
 
-    Ok(Note::new(self.path.to_owned()))
+    Note::new(self.path.to_owned())
   }
 
   /// Attempts to remove `name` as a link from the current note.
@@ -111,6 +125,8 @@ impl Note {
     let new = self
       .matter
       .links
+      .clone()
+      .unwrap_or_default()
       .iter()
       .filter(|link| *link != name)
       .map(|link| link.to_owned())
@@ -120,17 +136,17 @@ impl Note {
 
     file
       .write_all(
-        &Matter::into_string(Matter {
-          links: new,
+        &Matter::into(Matter {
+          links: Some(new),
           ..self.matter.clone()
-        })
+        })?
         .as_bytes(),
       )
       .unwrap();
 
     file.write_all(&self.content.as_bytes()).unwrap();
 
-    Ok(Note::new(self.path.to_owned()))
+    Note::new(self.path.to_owned())
   }
 
   /// Attempts to add `name` as a tag to the current note.
@@ -150,6 +166,8 @@ impl Note {
     let mut new = self
       .matter
       .tags
+      .clone()
+      .unwrap_or_default()
       .iter()
       .map(|tag| tag.to_owned())
       .collect::<Vec<String>>();
@@ -160,17 +178,17 @@ impl Note {
 
     file
       .write_all(
-        &Matter::into_string(Matter {
-          tags: new,
+        &Matter::into(Matter {
+          tags: Some(new),
           ..self.matter.clone()
-        })
+        })?
         .as_bytes(),
       )
       .unwrap();
 
     file.write_all(&self.content.as_bytes()).unwrap();
 
-    Ok(Note::new(self.path.to_owned()))
+    Note::new(self.path.to_owned())
   }
 
   /// Attempts to remove `name` as a tag from the current note.
@@ -190,6 +208,8 @@ impl Note {
     let new = self
       .matter
       .tags
+      .clone()
+      .unwrap_or_default()
       .iter()
       .filter(|tag| *tag != name)
       .map(|tag| tag.to_owned())
@@ -199,17 +219,17 @@ impl Note {
 
     file
       .write_all(
-        &Matter::into_string(Matter {
-          tags: new,
+        &Matter::into(Matter {
+          tags: Some(new),
           ..self.matter.clone()
-        })
+        })?
         .as_bytes(),
       )
       .unwrap();
 
     file.write_all(&self.content.as_bytes()).unwrap();
 
-    Ok(Note::new(self.path.to_owned()))
+    Note::new(self.path.to_owned())
   }
 }
 

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -22,7 +22,7 @@ pub fn create(note_id: &NoteId) -> Result<Note, Error> {
     .write_all(&Matter::default(&note_id.name))
     .context(error::Io)?;
 
-  Ok(Note::new(path))
+  Note::new(path)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This PR uses serde_yaml instead of rust_yaml for serialization and deserializing a notes frontmatter. This also adds additional error handling.

Ref:
- #1 
- #8 